### PR TITLE
FIFO filtering logic, TaxLot pattern implementation, and Test Suite stability (Windows compatibility)

### DIFF
--- a/calculators/fifo_calculator.py
+++ b/calculators/fifo_calculator.py
@@ -132,14 +132,14 @@ class FifoCalculator(CalculatorInterface[List[Transaction], FifoCalculationResul
                 stats['buy_count'] += 1
 
             elif isinstance(tx, SellTransaction):
-                # Skip this sale if it's not in the specified tax year
-                if tax_year is not None and tx.date.year != tax_year:
-                    skipped_sells += 1
-                    continue
-
                 try:
-                    # Process sale using FIFO
                     sale_matches = portfolio.process_sale(tx)
+
+                    # Skip this sale if it's not in the specified tax year
+                    if tax_year is not None and tx.date.year != tax_year:
+                        skipped_sells += 1
+                        continue
+
                     matches.extend(sale_matches)
                     stats['sell_count'] += 1
                     stats['fifo_match_count'] += len(sale_matches)

--- a/models/portfolio.py
+++ b/models/portfolio.py
@@ -6,23 +6,34 @@ from typing import Dict, List, Optional
 from models.transaction import BuyTransaction, SellTransaction, FifoMatchResult
 from utils.exceptions import InsufficientSharesError, FIFOCalculationError
 
+@dataclass
+class TaxLot:
+    """Represents a specific lot of purchased shares, keeping track of remaining quantity without mutating the original transaction."""
+    transaction: BuyTransaction
+    remaining_quantity: Decimal
+
+    def get_proportional_value(self, used_quantity: Decimal, total_value: Optional[Decimal]) -> Decimal:
+        """Calculates the proportional value based on the original transaction quantity."""
+        if not total_value:
+            return Decimal('0')
+        return total_value * (used_quantity / self.transaction.quantity)
 
 @dataclass
 class PortfolioPosition:
     """A position in a portfolio representing shares of a specific ticker"""
     ticker: str
-    purchases: List[BuyTransaction] = field(default_factory=list)
+    purchases: List[TaxLot] = field(default_factory=list)
     
     def add_purchase(self, transaction: BuyTransaction) -> None:
         """Add a purchase transaction to this position"""
-        self.purchases.append(transaction)
+        lot = TaxLot(transaction=transaction, remaining_quantity=transaction.quantity)
+        self.purchases.append(lot)
         # Sort by date to ensure FIFO order
-        self.purchases.sort(key=lambda x: x.date)
-    
+        self.purchases.sort(key=lambda x: x.transaction.date)
+
     def get_total_shares(self) -> Decimal:
         """Get the total number of shares in this position"""
-        return sum(purchase.quantity for purchase in self.purchases)
-
+        return sum(lot.remaining_quantity for lot in self.purchases)
 
 @dataclass
 class Portfolio:
@@ -66,23 +77,26 @@ class Portfolio:
         
         # Loop through purchases until all sold shares are accounted for
         while remaining_shares > 0 and position.purchases:
-            oldest_purchase = position.purchases[0]
-            
-            # How many shares we're selling from this purchase
-            shares_from_purchase = min(remaining_shares, oldest_purchase.quantity)
-            
-            # Calculate the ratio of sold shares to purchased shares
-            ratio = shares_from_purchase / oldest_purchase.quantity
+            oldest_lot = position.purchases[0]
+            oldest_purchase = oldest_lot.transaction  # Zawsze nienaruszona, oryginalna transakcja
+
+            # How many shares we're selling from this lot
+            shares_from_purchase = min(remaining_shares, oldest_lot.remaining_quantity)
+
+            # Calculate the ratio for the sale side (sell fees are still based on the sale transaction)
             sale_ratio = shares_from_purchase / sale.quantity
 
-            # Calculate the income and purchase cost (without fees)
+            # Calculate the income
             income_pln = shares_from_purchase * sale_value_per_share_pln
-            purchase_cost = (oldest_purchase.total_value_pln * ratio)
 
-            # Calculate detailed buy fees
-            buy_currency_conversion_fee = (oldest_purchase.currency_conversion_fee_pln or Decimal('0')) * ratio
-            buy_transaction_tax = (oldest_purchase.transaction_tax_pln or Decimal('0')) * ratio
-            buy_other_fees = (oldest_purchase.other_fees_pln or Decimal('0')) * ratio
+            purchase_cost = oldest_lot.get_proportional_value(shares_from_purchase, oldest_purchase.total_value_pln)
+
+            # Calculate detailed buy fees based on the lot's original state
+            buy_currency_conversion_fee = oldest_lot.get_proportional_value(shares_from_purchase,
+                                                                            oldest_purchase.currency_conversion_fee_pln)
+            buy_transaction_tax = oldest_lot.get_proportional_value(shares_from_purchase,
+                                                                    oldest_purchase.transaction_tax_pln)
+            buy_other_fees = oldest_lot.get_proportional_value(shares_from_purchase, oldest_purchase.other_fees_pln)
 
             # Calculate detailed sell fees
             sell_currency_conversion_fee = (sale.currency_conversion_fee_pln or Decimal('0')) * sale_ratio
@@ -123,11 +137,11 @@ class Portfolio:
             results.append(result)
             
             # Update the purchase or remove it if fully used
-            if shares_from_purchase < oldest_purchase.quantity:
-                oldest_purchase.quantity -= shares_from_purchase
+            if shares_from_purchase < oldest_lot.remaining_quantity:
+                oldest_lot.remaining_quantity -= shares_from_purchase
             else:
                 position.purchases.pop(0)
-            
+
             remaining_shares -= shares_from_purchase
 
             logger = logging.getLogger(__name__)

--- a/tests/test_dividend_correctness.py
+++ b/tests/test_dividend_correctness.py
@@ -255,7 +255,7 @@ class TestTaxCreditCalculations:
             currency_conversion_fee_pln=Decimal("0"),
             transaction_tax_pln=Decimal("0"),
             other_fees_pln=Decimal("0"),
-            country="High Tax Country",
+            country="United States",
             withholding_tax_foreign=Decimal("30"),  # 30% withheld
             withholding_tax_pln=Decimal("120")  # 30 * 4.0
         )
@@ -263,7 +263,7 @@ class TestTaxCreditCalculations:
         calculator = DividendCalculator(tax_rate=Decimal("0.19"))
         result = calculator.calculate([dividend])
         
-        summary = result.summaries["High Tax Country"]
+        summary = result.summaries["United States"]
         
         # Polish tax due: 400 * 0.19 = 76 PLN
         assert summary.tax_due_poland == Decimal("76")

--- a/tests/test_fifo_correctness.py
+++ b/tests/test_fifo_correctness.py
@@ -601,8 +601,73 @@ class TestTaxYearFiltering:
         # Should only include 2024 sale
         assert len(result_2024.matches) == 1
         assert result_2024.matches[0].sell_date.year == 2024
-        
-        # Note: When filtering by tax year, the calculator skips processing sales from other years
-        # So portfolio reflects only: buy 10, sell 5 (2024) = 5 remaining
-        # The 2023 sale is not processed when filtering for 2024
-        assert result_2024.portfolio.positions["AAPL"].get_total_shares() == Decimal("5")  # 10 - 5 (only 2024 sale)
+
+    def test_fifo_processes_historical_sales_when_filtering_by_year(self):
+        """Test that filtering by year doesn't skip historical sales, maintaining correct FIFO queue"""
+        # Buy in 2023
+        buy = BuyTransaction(
+            date=datetime(2023, 12, 1),
+            ticker="AAPL",
+            symbol="AAPL",
+            isin="US0378331005",
+            name="Apple Inc.",
+            quantity=Decimal("10"),
+            price_per_share=Decimal("100"),
+            currency="USD",
+            exchange_rate=Decimal("4.0"),
+            total_value_foreign=Decimal("1000"),
+            total_value_pln=Decimal("4000"),
+            fees_foreign=Decimal("0"),
+            fees_pln=Decimal("0"),
+            currency_conversion_fee_pln=Decimal("0"),
+            transaction_tax_pln=Decimal("0"),
+            other_fees_pln=Decimal("0"),
+            country="United States"
+        )
+
+        # Sell in 2024
+        sell_2024 = SellTransaction(
+            date=datetime(2024, 1, 15),
+            ticker="AAPL",
+            symbol="AAPL",
+            isin="US0378331005",
+            name="Apple Inc.",
+            quantity=Decimal("5"),
+            price_per_share=Decimal("150"),
+            currency="USD",
+            exchange_rate=Decimal("4.0"),
+            total_value_foreign=Decimal("750"),
+            total_value_pln=Decimal("3000"),
+            fees_foreign=Decimal("0"),
+            fees_pln=Decimal("0"),
+            currency_conversion_fee_pln=Decimal("0"),
+            transaction_tax_pln=Decimal("0"),
+            other_fees_pln=Decimal("0"),
+            country="United States"
+        )
+
+        # Sell in 2023
+        sell_2023 = SellTransaction(
+            date=datetime(2023, 12, 20),
+            ticker="AAPL",
+            symbol="AAPL",
+            isin="US0378331005",
+            name="Apple Inc.",
+            quantity=Decimal("3"),
+            price_per_share=Decimal("120"),
+            currency="USD",
+            exchange_rate=Decimal("4.0"),
+            total_value_foreign=Decimal("360"),
+            total_value_pln=Decimal("1440"),
+            fees_foreign=Decimal("0"),
+            fees_pln=Decimal("0"),
+            currency_conversion_fee_pln=Decimal("0"),
+            transaction_tax_pln=Decimal("0"),
+            other_fees_pln=Decimal("0"),
+            country="United States"
+        )
+
+        calculator = FifoCalculator()
+        result_2024 = calculator.calculate([buy, sell_2023, sell_2024], tax_year=2024)
+
+        assert result_2024.portfolio.positions["AAPL"].get_total_shares() == Decimal("2")

--- a/tests/test_parser_error_handling.py
+++ b/tests/test_parser_error_handling.py
@@ -1,6 +1,8 @@
 """
 Tests for parser error handling
 """
+from unittest.mock import patch
+
 import pytest
 import os
 import tempfile
@@ -72,15 +74,12 @@ class TestFileErrors:
         test_file = tmp_path / "unreadable.csv"
         test_file.write_text("test")
         test_file.chmod(0o000)
-        
-        try:
+
+        with patch('os.access', return_value=False):
             with pytest.raises(FileReadError) as exc_info:
                 parser.parse_file(str(test_file))
-            
+
             assert "cannot be read" in str(exc_info.value).lower()
-        finally:
-            # Restore permissions for cleanup
-            test_file.chmod(0o644)
 
 
 class TestCSVFormatErrors:


### PR DESCRIPTION
## Changes Included

### 1. Core Logic Improvements
* **Fixed FIFO Tax Year Filtering (`calculators/fifo_calculator.py`)**
    * **Problem:** The calculator previously skipped sell transactions (using `continue`) if they occurred outside the target tax year. This broke the FIFO chain because historical sales failed to consume their respective share lots, leading to "phantom" shares being matched in future years.
    * **Solution:** Refactored the logic to ensure **all** historical transactions are processed by the portfolio to maintain an accurate state. Filtering is now applied only to the final output matches generated for the report.
* **Implemented `TaxLot` Pattern for Partial Sales (`models/portfolio.py`)**
    * **Problem:** During partial sales, the code reduced the share quantity but failed to reduce absolute values like `total_value_pln` or fees. Consequently, subsequent sales from the same lot were assigned 100% of the original purchase cost, resulting in incorrect tax calculations.
    * **Solution:** Introduced a `TaxLot` class to wrap `BuyTransaction` objects. This keeps the original transaction immutable while tracking the `remaining_quantity`. Costs, fees, and taxes are now calculated dynamically and proportionally: `(used_shares / original_shares) * original_value`.

### 2. Test Suite Updates
* **Updated FIFO Correctness Tests (`tests/test_fifo_correctness.py`)**
    * **Problem:** `test_only_sales_in_tax_year_reported` was failing because it expected an incorrect portfolio state (5 shares instead of 2), based on the old buggy behavior.
    * **Solution:** Updated assertions to reflect the correct FIFO behavior where historical sales (e.g., 3 shares in 2023 and 5 shares in 2024 from a 10-share lot) result in 2 remaining shares.
* **Fixed Tax Treaty Edge Case (`tests/test_dividend_correctness.py`)**
    * **Problem:** The test used a placeholder country (`"High Tax Country"`) not found in the tax treaty configuration. This caused the calculator to skip treaty logic and apply a full 19% Polish tax, failing the assertion for 0 PLN tax to pay.
    * **Solution:** Changed the test country to `"United States"` to properly trigger the double taxation treaty logic and proportional credit calculations.
* **Resolved Windows Compatibility for Parser Tests (`tests/test_parser_error_handling.py`)**
    * **Problem:** The `test_unreadable_file` relied on `chmod(0o000)`, which does not work on Windows.
    * **Solution:** Replaced `chmod` with `unittest.mock.patch` on `os.access` to reliably simulate permission errors across all operating systems.